### PR TITLE
Bugfixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.1.2
+Date: 02. 03. 2025
+  Bugfixes:
+    - Solve multiple crashes :
+    - Add support for cargo pods
+    - Add support for assembling machines
+    - Add support for boilers
+    - Add support for labs and implement a fix for factorio's 2.0.38 version
+    - Solve a crash with the mining drills, but only add limited support. If you use RSL to add spoilable ores, you need to define a fallback for your ore or set placeholder_spoil_into_self to true
+---------------------------------------------------------------------------------------------------
 Version: 0.1.1
 Date: 13. 02. 2025
   Bugfixes:

--- a/control.lua
+++ b/control.lua
@@ -31,6 +31,7 @@ local generic_source_handler = {
     ["mining-drill"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_mining_drill(entity, rsl_definition) end,
     ["boiler"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_boiler_inventory(entity, rsl_definition) end,
     ["lab"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_lab_inventory(entity, rsl_definition) end,
+    ["cargo-pod"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_cargo_pod(entity, rsl_definition) end,
 }
 
 local defined_inventories = {

--- a/control.lua
+++ b/control.lua
@@ -28,6 +28,9 @@ local generic_source_handler = {
     ["cargo-landing-pad"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_logistic_inventory(entity, rsl_definition) end,
     ["item-entity"] = function(entity, rsl_definition) return swap_funcs.hotswap_on_ground(entity, rsl_definition) end,
     ["furnace"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_furnace(entity, rsl_definition) end,
+    ["mining-drill"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_mining_drill(entity, rsl_definition) end,
+    ["boiler"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_boiler_inventory(entity, rsl_definition) end,
+    ["lab"] = function(entity, rsl_definition) return swap_funcs.hotswap_in_lab_inventory(entity, rsl_definition) end,
 }
 
 local defined_inventories = {

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,3 +1,24 @@
 for _, machine in pairs(data.raw["assembling-machine"]) do
     machine.trash_inventory_size = 5
 end
+
+-- Check if Factorio version is >= required_version
+local function is_version_or_higher(required_version)
+    local game_version = util.split(mods["base"], ".") -- Get game version from "base" mod
+    for i = 1, #required_version do
+        local v = tonumber(game_version[i]) or 0
+        if v > required_version[i] then return true end
+        if v < required_version[i] then return false end
+    end
+    return true  -- Exact match or higher
+end
+
+
+local factorio_version = data.raw["utility-constants"].defaults
+
+-- Apply changes only if Factorio engine version is >= 2.0.38
+if is_version_or_higher({2, 0, 38}) then
+    for _, lab in pairs(data.raw["lab"]) do
+        lab.trash_inventory_size = 5
+    end
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,3 @@
+for _, machine in pairs(data.raw["assembling-machine"]) do
+    machine.trash_inventory_size = 5
+end

--- a/data_registry.lua
+++ b/data_registry.lua
@@ -4,12 +4,15 @@ local placeholder_spoil_into_self = false
 --- !!! README !!! \
 --- When you want to control the behavior of a spoiling item at runtime, you need a placeholder intermediary.
 --- When your item spoils, it is replaced by the placeholder that is then targeted by the runtime script.\
---- However, some things cannot have their inventory written into arbitrarly (like assembling machines).
+--- However, some things cannot have their inventory written into arbitrarly or use internal buffers that aren't accessible.
 --- If placeholder_spoil_into_self is set to false, the placeholder will disappear after 2 seconds of life. \
---- it will be like your item just fanished on spoil if for any reason, the script wasn't able to replace it properly.\
+--- it will be like your item just vanished on spoil if for any reason, the script wasn't able to replace it properly.\
 --- If it is set to true, then the placeholder will spoil into itself and await for a valid state where it can be replaced. \
 --- I would advise to let this at false because having a LOT of placeholders accumulate somewhere they cannot spoil will hinder
 --- performance by triggering a remplacement attempt every 2 seconds.
+--- HOWEVER : if you add a new ore, or make an ore spoilable, you need to either set placeholder_spoil_into_self to true,
+--- or define a fallback in your ore item, because mining_drills have an internal buffer where the item is, and it cannot
+--- be accessed through the API for now.
 --- Use it for debugging only (to see where items are stuck and cannot be replaced).
 ---@param value boolean
 function registry.set_placeholder_spoil_into_self(value)
@@ -77,6 +80,9 @@ function registry.register_spoilable_item(item, items_per_trigger, fallback_spoi
     if not placeholder_spoil_into_self then
         placeholder.spoil_result = fallback_spoilage or nil
         placeholder.spoil_to_trigger_result = nil
+    else
+        placeholder.spoil_result = placeholder.name
+        placeholder.spoil_to_trigger_result = item.spoil_to_trigger_result
     end
 
     data:extend{item, placeholder}

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "runtime-spoilage-library",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"title": "Runtime spoilage library",
 	"author": "SirPuck",
 	"homepage": "https://discord.gg/DBW37M34NX",

--- a/swap_inventories.lua
+++ b/swap_inventories.lua
@@ -204,7 +204,17 @@ end
 --- @param rsl_definition RslDefinition the name of the placeholder item.
 --- @return nil
 function swap_funcs.hotswap_in_bot(entity, rsl_definition)
-    --local result = math.random() < 0.5 and "iron-plate" or "copper-plate"
+    local stack = entity.get_inventory(1)[1]
+    if stack.valid_for_read then
+        local result = select_result(rsl_definition)
+        swap_funcs.set_or_nil_stack(stack, result)
+    end
+end
+
+--- @param entity LuaEntity (we assume source_entity and target_entity are the same).
+--- @param rsl_definition RslDefinition the name of the placeholder item.
+--- @return nil
+function swap_funcs.hotswap_in_cargo_pod(entity, rsl_definition)
     local stack = entity.get_inventory(1)[1]
     if stack.valid_for_read then
         local result = select_result(rsl_definition)


### PR DESCRIPTION
Version: 0.1.2
Date: 02. 03. 2025
  Bugfixes:
    - Solve multiple crashes :
    - Add support for cargo pods
    - Add support for assembling machines
    - Add support for boilers
    - Add support for labs and implement a fix for factorio's 2.0.38 version
    - Solve a crash with the mining drills, but only add limited support. If you use RSL to add spoilable ores, you need to define a fallback for your ore or set placeholder_spoil_into_self to true
---------------------------------------------------------------------------------------------------